### PR TITLE
Add loop unrolling threshhold to static memory tagging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ examples/build
 .idea
 
 *.cwasm
+*.s
 
 .direnv
 

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -3559,6 +3559,8 @@ fn assert_16_byte_aligned(val: Value, builder: &mut FunctionBuilder) {
         .trapnz(is_aligned, ir::TrapCode::HeapMisaligned);
 }
 
+// TODO: mention EL0 instruction `stgm` somewhere, which we couldn't use unfortunately
+
 /// This helper function iterates over `iter_ptr` for `size` bytes and tags
 /// every 16 bytes of memory using the ARM `stg` instruction with the tag
 /// found in `tagged_ptr`.
@@ -3579,22 +3581,116 @@ where
             imm,
         } = builder.func.dfg.insts[inst]
         {
-            let size = imm.bits();
+            let size_static = imm.bits() as u64;
 
-            return tag_memory_region_static(iter_ptr, tagged_ptr, size, builder);
+            return tag_memory_region_static(
+                iter_ptr,
+                tagged_ptr,
+                size_static,
+                size,
+                builder,
+                environ,
+            );
         }
     }
 
     tag_memory_region_dynamic(iter_ptr, tagged_ptr, size, builder, environ)
 }
 
-/// Tag a memory region with a known size.
-fn tag_memory_region_static(
+/// Tag a memory region which has a static size known at compile-time.
+/// Iterate through `iter_ptr`, which will be set dynamically at runtime,
+/// starting at offset 0.
+/// Optimizations include:
+/// - Use st2g operation to tag two memory regions at once
+fn tag_memory_region_static_without_loop_unrolling_threshhold(
     iter_ptr: Value,
     tagged_ptr: Value,
-    size: i64,
+    size: u64,
     builder: &mut FunctionBuilder,
-) -> WasmResult<()> {
+) {
+    let mut i = 0;
+    while size - i >= 32 {
+        let cur_ptr = builder.ins().iadd_imm(iter_ptr, i as i64);
+        builder.ins().arm64_st2g(tagged_ptr, cur_ptr);
+        i += 32;
+    }
+    if i < size {
+        let cur_ptr = builder.ins().iadd_imm(iter_ptr, i as i64);
+        builder.ins().arm64_stg(tagged_ptr, cur_ptr);
+    }
+}
+
+/// Tag a memory region which has a static size known at compile-time.
+/// Optimizations include:
+/// - Use st2g operation to tag two memory regions at once
+/// - Only unroll loops until a certain threshhold, since very large sizes
+///   increase number of generated instructions and increase cache misses
+fn tag_memory_region_static<FE>(
+    iter_ptr: Value,
+    tagged_ptr: Value,
+    size: u64,
+    size_dynamic: Value,
+    builder: &mut FunctionBuilder,
+    environ: &mut FE,
+) -> WasmResult<()>
+where
+    FE: FuncEnvironment + ?Sized,
+{
+    // Runtime code that is generated:
+    //
+    // (compile-time) num_required_st2g_loops = floor(size / LOOP_UNROLL_BYTES_THRESHHOLD)
+    // (compile-time) num_required_last_stg = (size % LOOP_UNROLL_BYTES_THRESHHOLD) / 16
+    //
+    // (compile-time) if num_required_st2g_loops <= 1
+    // (compile-time)     generate WITHOUT_LOOP_UNROLLING_THRESHHOLD
+    // (compile-time) else
+    // (compile-time)     generate WITH_LOOP_UNROLLING_THRESHHOLD
+    //
+    // WITHOUT_LOOP_UNROLLING_THRESHHOLD:
+    // +---less_than_threshhold
+    // | st2g(tagged_ptr, iter_ptr + 0)          \
+    // | st2g(tagged_ptr, iter_ptr + 32)          | repeat `n` times, i.e. while (remaining_bits >= 32) holds
+    // | ...                                      |
+    // | st2g(tagged_ptr, iter_ptr + (n-1) * 32) /
+    // |
+    // | stg(tagged_ptr, iter_ptr + n * 32)  | generate only if required
+    // +---
+    //
+    // WITH_LOOP_UNROLLING_THRESHHOLD:
+    // end_ptr = iter_ptr + size
+    // +---st2g_loop_condition_block(iter_ptr)
+    // | if (iter_ptr < end_ptr)
+    // |     goto st2g_loop_body_block(iter_ptr)
+    // | else
+    // |     goto last_stgs_block
+    // |
+    // | +---st2g_loop_body_block(iter_ptr, st2g_loop_counter)
+    // | | st2g(tagged_ptr, iter_ptr + 0)          \
+    // | | st2g(tagged_ptr, iter_ptr + 32)          | repeat `n`=LOOP_UNROLL_BYTES_THRESHHOLD times
+    // | | ...                                      |
+    // | | st2g(tagged_ptr, iter_ptr + (n-1) * 32) /
+    // | |
+    // | | iter_ptr += LOOP_UNROLL_BYTES_THRESHHOLD
+    // | | goto st2g_loop_condition_block(iter_ptr)
+    // | +---
+    // +---
+    //
+    // +---last_stgs_block(iter_ptr)
+    // | st2g(tagged_ptr, iter_ptr + 0)          \
+    // | st2g(tagged_ptr, iter_ptr + 32)          | repeat `n` times, i.e. while (remaining_bits >= 32) holds
+    // | ...                                      |
+    // | st2g(tagged_ptr, iter_ptr + (n-1) * 32) /
+    // |
+    // | stg(tagged_ptr, iter_ptr + n * 32)  | generate only if required
+    // +---
+
+    // If the number of bytes to be tagged is larger than this threshhold,
+    // insert a loop that tags using `st2g` chunks.
+    // Threshhold should be a multiple of 32, so each `st2g` chunk can be
+    // exactly divided into only 32-byte tagging `st2g` instructions
+    // This constant was adapted from clang.
+    const LOOP_UNROLL_BYTES_THRESHHOLD: u32 = 160;
+
     // Assert that `size` is 16 byte aligned, and trap if not
     if size % 16 != 0 {
         return Err(WasmError::User(format!(
@@ -3602,27 +3698,98 @@ fn tag_memory_region_static(
         )));
     }
 
-    // First insert an overflow check. This allows us to insert non-trapping instructions later.
-    let c = builder.ins().iconst(I64, size);
-    builder
-    .ins()
-    .uadd_overflow_trap(iter_ptr, c, ir::TrapCode::HeapOutOfBounds);
+    // TODO: maybe optimize by adding `size` statically as immediate
+    // Trap if (iter_ptr + size) overflows, so we can use non-trapping instructions later
+    let end_ptr =
+        builder
+            .ins()
+            .uadd_overflow_trap(iter_ptr, size_dynamic, ir::TrapCode::HeapOutOfBounds);
 
-    let mut i = 0;
-    while size - i >= 32 {
-        let iter_ptr = builder.ins().iadd_imm(iter_ptr, i);
-        builder.ins().arm64_st2g(tagged_ptr, iter_ptr);
-        i += 32;
-    }
-    if i < size {
-        let iter_ptr = builder.ins().iadd_imm(iter_ptr, i);
-        builder.ins().arm64_stg(tagged_ptr, iter_ptr);
+    // In Rust, for u64: (a / b) == floor(a / b), which we make use of here
+    let num_required_st2g_loops: u64 = size / u64::from(LOOP_UNROLL_BYTES_THRESHHOLD);
+
+    if num_required_st2g_loops <= 1 {
+        // WITHOUT_LOOP_UNROLLING_THRESHHOLD
+
+        tag_memory_region_static_without_loop_unrolling_threshhold(
+            iter_ptr, tagged_ptr, size, builder,
+        );
+    } else {
+        // WITH_LOOP_UNROLLING_THRESHHOLD
+
+        // === Block definitions
+        // st2g_loop_condition_block(iter_ptr)
+        let st2g_loop_condition_block = block_with_params(builder, [ValType::I64], environ)?;
+
+        // st2g_loop_body_block(iter_ptr)
+        let st2g_loop_body_block = block_with_params(builder, [ValType::I64], environ)?;
+
+        // last_stgs_block(iter_ptr)
+        let last_stgs_block = block_with_params(builder, [ValType::I64], environ)?;
+
+        builder.ins().jump(st2g_loop_condition_block, &[iter_ptr]);
+
+        // === st2g_loop_condition_block(iter_ptr)
+        builder.switch_to_block(st2g_loop_condition_block);
+
+        let iter_ptr = builder.block_params(st2g_loop_condition_block)[0];
+
+        // TODO: the only potential optimization concern is that we now have to use a normal `icmp` over an `icmp_imm`, maybe this is slower?
+        let cond = builder
+            .ins()
+            .icmp(IntCC::UnsignedLessThan, iter_ptr, end_ptr);
+
+        canonicalise_brif(
+            builder,
+            cond,
+            st2g_loop_body_block,
+            &[iter_ptr],
+            last_stgs_block,
+            &[iter_ptr],
+        );
+
+        // === st2g_loop_body_block(iter_ptr)
+        builder.switch_to_block(st2g_loop_body_block);
+
+        let iter_ptr = builder.block_params(st2g_loop_body_block)[0];
+
+        for i in 0..(LOOP_UNROLL_BYTES_THRESHHOLD / 32) {
+            let cur_ptr = builder.ins().iadd_imm(iter_ptr, i64::from(i * 32));
+            builder.ins().arm64_st2g(tagged_ptr, cur_ptr);
+        }
+
+        let iter_ptr = builder
+            .ins()
+            .iadd_imm(iter_ptr, i64::from(LOOP_UNROLL_BYTES_THRESHHOLD));
+
+        builder.ins().jump(st2g_loop_condition_block, &[iter_ptr]);
+
+        builder.seal_block(st2g_loop_body_block);
+        builder.seal_block(st2g_loop_condition_block);
+
+        // === last_stgs_block(iter_ptr)
+        builder.switch_to_block(last_stgs_block);
+
+        let iter_ptr = builder.block_params(last_stgs_block)[0];
+
+        let remaining_offset = num_required_st2g_loops * u64::from(LOOP_UNROLL_BYTES_THRESHHOLD);
+        let remaining_size = size - remaining_offset;
+
+        tag_memory_region_static_without_loop_unrolling_threshhold(
+            iter_ptr,
+            tagged_ptr,
+            remaining_size,
+            builder,
+        );
+
+        builder.seal_block(last_stgs_block);
     }
 
     Ok(())
 }
 
-/// Optimized implementation of tag_memory_region. Optimizations include:
+/// Tag a memory region which has a dynamic size unknown at compile-time.
+/// Optimizations include:
 /// - Use st2g operation to tag two memory regions at once
 fn tag_memory_region_dynamic<FE>(
     iter_ptr: Value,
@@ -3637,6 +3804,7 @@ where
     // Pseudo code (high level):
     //
     // assert_16_byte_aligned(size)
+    // assert_no_overflow(iter_ptr + size)
     //
     // for (size; size >= 32; size -= 32, iter_ptr += 32)
     //    st2g(tagged_ptr, iter_ptr)
@@ -3676,15 +3844,22 @@ where
 
     assert_16_byte_aligned(size, builder);
 
+    // Trap if (iter_ptr + size) overflows, so we can use non-trapping instructions later
+    builder
+        .ins()
+        .uadd_overflow_trap(iter_ptr, size, ir::TrapCode::HeapOutOfBounds);
+
     // === Block definitions
     // st2g_loop_condition_block(size, iter_ptr)
-    let st2g_loop_condition_block = block_with_params(builder, [ValType::I64, ValType::I64], environ)?;
+    let st2g_loop_condition_block =
+        block_with_params(builder, [ValType::I64, ValType::I64], environ)?;
 
     // st2g_loop_body_block(size, iter_ptr)
     let st2g_loop_body_block = block_with_params(builder, [ValType::I64, ValType::I64], environ)?;
 
     // last_stg_condition_block(size, iter_ptr)
-    let last_stg_condition_block = block_with_params(builder, [ValType::I64, ValType::I64], environ)?;
+    let last_stg_condition_block =
+        block_with_params(builder, [ValType::I64, ValType::I64], environ)?;
 
     // last_stg_body_block(size, iter_ptr)
     let last_stg_body_block = block_with_params(builder, [ValType::I64, ValType::I64], environ)?;
@@ -3692,8 +3867,9 @@ where
     // next_block()
     let next_block = block_with_params(builder, [], environ)?;
 
-
-    builder.ins().jump(st2g_loop_condition_block, &[size, iter_ptr]);
+    builder
+        .ins()
+        .jump(st2g_loop_condition_block, &[size, iter_ptr]);
 
     // === st2g loop condition block
     builder.switch_to_block(st2g_loop_condition_block);
@@ -3701,7 +3877,9 @@ where
     let size = builder.block_params(st2g_loop_condition_block)[0];
     let iter_ptr = builder.block_params(st2g_loop_condition_block)[1];
 
-    let cond = builder.ins().icmp_imm(IntCC::UnsignedGreaterThanOrEqual, size, 32);
+    let cond = builder
+        .ins()
+        .icmp_imm(IntCC::UnsignedGreaterThanOrEqual, size, 32);
     canonicalise_brif(
         builder,
         cond,
@@ -3720,13 +3898,11 @@ where
     builder.ins().arm64_st2g(tagged_ptr, iter_ptr);
 
     let size_counter = builder.ins().iadd_imm(size_counter, -32);
-    let offset = builder.ins().iconst(I64, 32);
-    let iter_ptr =
-        builder
-            .ins()
-            .uadd_overflow_trap(iter_ptr, offset, ir::TrapCode::HeapOutOfBounds);
+    let iter_ptr = builder.ins().iadd_imm(iter_ptr, 32);
 
-    builder.ins().jump(st2g_loop_condition_block, &[size_counter, iter_ptr]);
+    builder
+        .ins()
+        .jump(st2g_loop_condition_block, &[size_counter, iter_ptr]);
 
     builder.seal_block(st2g_loop_body_block);
     builder.seal_block(st2g_loop_condition_block);

--- a/tests/mem_safety/test_stg_st2g_code_generation.wast
+++ b/tests/mem_safety/test_stg_st2g_code_generation.wast
@@ -1,0 +1,301 @@
+;; These are some "test-cases" to check whether wasmtime generates the expected
+;; combination of stg, st2g and loops for different wast input files.
+;;
+;; How to run:
+;; 1. Compile this file using wasmtime:
+;; wasmtime compile --target aarch64-unknown-linux-gnu --cranelift-enable use_mte --wasm-features=memory64,mem-safety <this-file>
+;; 2. Look at the generated asm code with `llvm-objdump`
+;; llvm-objdump -D test_stg_st2g_code_generation.cwasm > tmp.s
+;;
+;; Note: the test-cases have been numbered, since they are also named `_wasm_function_n` in objdump's output
+
+(module
+  (memory i64 1 1)
+  (global $sp (mut i32) (i32.const 64))
+
+
+  ;; Test 0:
+  ;;
+  ;; Equivalent C function:
+  ;;
+  ;; int foo() {
+  ;;   int x[4];
+  ;;   x[0] = 42;
+  ;;   return x[0];
+  ;; }
+  ;;
+  ;; What stg/st2g instructions should be generated:
+  ;; stg
+  ;;
+  (func (export "one_stg") (result i32)
+        ;; int x[4]; (1 int is 4 bytes, 4 * 4 bytes = 16 bytes total)
+        (local $ptr i64) ;; declare variable ptr
+
+        ;; tag memory region
+        (i64.const 0) ;; index (offset/ptr in wasm linear memory)
+        (i64.const 16) ;; size of region we want to tag
+        (segment.stack_new) ;; returns tagged_index on stack
+        (local.tee $ptr) ;; store tagged_index into $ptr
+
+        ;; x[0] = 42;
+        (i32.const 42) ;; push 42 on stack
+        (i32.store) ;; store value 42 into $ptr (ptr[0] = 42)
+
+        ;; push ptr[0] onto stack
+        (local.get $ptr) ;; push $ptr onto stack
+        (i32.load) ;; push back ptr[0] onto stack
+
+        ;; untag memory region
+        (local.get $ptr) ;; push $ptr value to stack
+        (i64.const 0) ;; index
+        (i64.const 16) ;; size
+        (segment.stack_free)
+
+        ;; return x[0];
+        (return)
+  )
+
+
+
+  ;; Test 1:
+  ;;
+  ;; Equivalent C function:
+  ;;
+  ;; int foo() {
+  ;;   int x[20];
+  ;;   x[0] = 42;
+  ;;   return x[0];
+  ;; }
+  ;;
+  ;; What stg/st2g instructions should be generated:
+  ;; st2g
+  ;; st2g
+  ;; stg
+  ;;
+  (func (export "less_than_one_threshhold") (result i32)
+        ;; int x[20]; (1 int is 4 bytes, 4 * 20 bytes = 80 bytes total)
+        (local $ptr i64) ;; declare variable ptr
+
+        ;; tag memory region
+        (i64.const 0) ;; index (offset/ptr in wasm linear memory)
+        (i64.const 80) ;; size of region we want to tag
+        (segment.stack_new) ;; returns tagged_index on stack
+        (local.tee $ptr) ;; store tagged_index into $ptr
+
+        ;; x[0] = 42;
+        (i32.const 42) ;; push 42 on stack
+        (i32.store) ;; store value 42 into $ptr (ptr[0] = 42)
+
+        ;; push ptr[0] onto stack
+        (local.get $ptr) ;; push $ptr onto stack
+        (i32.load) ;; push back ptr[0] onto stack
+
+        ;; untag memory region
+        (local.get $ptr) ;; push $ptr value to stack
+        (i64.const 0) ;; index
+        (i64.const 80) ;; size
+        (segment.stack_free)
+
+        ;; return x[0];
+        (return)
+  )
+
+
+
+  ;; Test 2:
+  ;;
+  ;; Equivalent C function:
+  ;;
+  ;; int foo() {
+  ;;   int x[40];
+  ;;   x[0] = 42;
+  ;;   return x[0];
+  ;; }
+  ;;
+  ;; What stg/st2g instructions should be generated:
+  ;; st2g
+  ;; st2g
+  ;; st2g
+  ;; st2g
+  ;; st2g
+  ;;
+  (func (export "exactly_one_threshhold") (result i32)
+        ;; int x[40]; (1 int is 4 bytes, 4 * 40 bytes = 160 bytes total)
+        (local $ptr i64) ;; declare variable ptr
+
+        ;; tag memory region
+        (i64.const 0) ;; index (offset/ptr in wasm linear memory)
+        (i64.const 160) ;; size of region we want to tag
+        (segment.stack_new) ;; returns tagged_index on stack
+        (local.tee $ptr) ;; store tagged_index into $ptr
+
+        ;; x[0] = 42;
+        (i32.const 42) ;; push 42 on stack
+        (i32.store) ;; store value 42 into $ptr (ptr[0] = 42)
+
+        ;; push ptr[0] onto stack
+        (local.get $ptr) ;; push $ptr onto stack
+        (i32.load) ;; push back ptr[0] onto stack
+
+        ;; untag memory region
+        (local.get $ptr) ;; push $ptr value to stack
+        (i64.const 0) ;; index
+        (i64.const 160) ;; size
+        (segment.stack_free)
+
+        ;; return x[0];
+        (return)
+  )
+
+
+
+  ;; Test 3:
+  ;;
+  ;; Equivalent C function:
+  ;;
+  ;; int foo() {
+  ;;   int x[76];
+  ;;   x[0] = 42;
+  ;;   return x[0];
+  ;; }
+  ;;
+  ;; What stg/st2g instructions should be generated:
+  ;; st2g
+  ;; st2g
+  ;; st2g
+  ;; st2g
+  ;; st2g
+  ;;
+  ;; st2g
+  ;; st2g
+  ;; st2g
+  ;; st2g
+  ;; stg
+  ;;
+  (func (export "just_less_than_two_threshholds") (result i32)
+        ;; int x[76]; (1 int is 4 bytes, 4 * 76 bytes = 2*160 - 16 = 304 bytes total)
+        (local $ptr i64) ;; declare variable ptr
+
+        ;; tag memory region
+        (i64.const 0) ;; index (offset/ptr in wasm linear memory)
+        (i64.const 304) ;; size of region we want to tag
+        (segment.stack_new) ;; returns tagged_index on stack
+        (local.tee $ptr) ;; store tagged_index into $ptr
+
+        ;; x[0] = 42;
+        (i32.const 42) ;; push 42 on stack
+        (i32.store) ;; store value 42 into $ptr (ptr[0] = 42)
+
+        ;; push ptr[0] onto stack
+        (local.get $ptr) ;; push $ptr onto stack
+        (i32.load) ;; push back ptr[0] onto stack
+
+        ;; untag memory region
+        (local.get $ptr) ;; push $ptr value to stack
+        (i64.const 0) ;; index
+        (i64.const 304) ;; size
+        (segment.stack_free)
+
+        ;; return x[0];
+        (return)
+  )
+
+
+
+  ;; Test 4:
+  ;;
+  ;; Equivalent C function:
+  ;;
+  ;; int foo() {
+  ;;   int x[132];
+  ;;   x[0] = 42;
+  ;;   return x[0];
+  ;; }
+  ;;
+  ;; What stg/st2g instructions should be generated:
+  ;; for _ in 0..3:
+  ;;   st2g
+  ;;   st2g
+  ;;   st2g
+  ;;   st2g
+  ;;   st2g
+  ;; st2g
+  ;; stg
+  ;;
+  (func (export "multiple_threshhold_loops") (result i32)
+        ;; int x[132]; (1 int is 4 bytes, 4 * 132 bytes = 528 bytes total)
+        (local $ptr i64) ;; declare variable ptr
+
+        ;; tag memory region
+        (i64.const 0) ;; index (offset/ptr in wasm linear memory)
+        (i64.const 528) ;; size of region we want to tag
+        (segment.stack_new) ;; returns tagged_index on stack
+        (local.tee $ptr) ;; store tagged_index into $ptr
+
+        ;; x[0] = 42;
+        (i32.const 42) ;; push 42 on stack
+        (i32.store) ;; store value 42 into $ptr (ptr[0] = 42)
+
+        ;; push ptr[0] onto stack
+        (local.get $ptr) ;; push $ptr onto stack
+        (i32.load) ;; push back ptr[0] onto stack
+
+        ;; untag memory region
+        (local.get $ptr) ;; push $ptr value to stack
+        (i64.const 0) ;; index
+        (i64.const 528) ;; size
+        (segment.stack_free)
+
+        ;; return x[0];
+        (return)
+  )
+
+
+
+  ;; Test 5:
+  ;;
+  ;; Equivalent C function:
+  ;;
+  ;; int foo(int i) {
+  ;;   int x[i];
+  ;;   x[0] = 42;
+  ;;   return x[0];
+  ;; }
+  ;;
+  ;; What stg/st2g instructions should be generated:
+  ;; Completely dynamic, no static optimizations
+  ;;
+  (func (export "non_constant_dynamic_length") (param $i i64) (result i32)
+        ;; int x[i]; (1 int is 4 bytes, 4 * i bytes total)
+        (local $ptr i64) ;; declare variable ptr
+
+        ;; i *= 4 to get total bytes
+        (local.get $i)
+        (i64.const 4)
+        (i64.mul)
+        (local.set $i)
+
+        ;; tag memory region
+        (i64.const 0) ;; index (offset/ptr in wasm linear memory)
+        (local.get $i) ;; size of region we want to tag
+        (segment.stack_new) ;; returns tagged_index on stack
+        (local.tee $ptr) ;; store tagged_index into $ptr
+
+        ;; x[0] = 42;
+        (i32.const 42) ;; push 42 on stack
+        (i32.store) ;; store value 42 into $ptr (ptr[0] = 42)
+
+        ;; push ptr[0] onto stack
+        (local.get $ptr) ;; push $ptr onto stack
+        (i32.load) ;; push back ptr[0] onto stack
+
+        ;; untag memory region
+        (local.get $ptr) ;; push $ptr value to stack
+        (i64.const 0) ;; index
+        (local.get $i) ;; size
+        (segment.stack_free)
+
+        ;; return x[0];
+        (return)
+  )
+)


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
In case the static size (meaning we know it at compile-time) of the memory region we want to tag is very large, continueing to unroll the entire loop into a very large number of `st2g` instructions may cause unwanted inefficiencies (e.g. cache misses). Therefore, we should introduce a threshhold (some integer value, which we can adapt from clang in the future) with the following behaviour: Unroll at most this amount of st2g instructions directly, otherwise unroll st2g loops in runtime loops.