### PR TITLE
Removed required target feature mte to enable cross compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+[env]
+CC_aarch64-unknown-linux-gnu = "aarch64-linux-gnu-gcc"
+CC_aarch64-unknown-linux-musl = "aarch64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+rustflags = ["-C", "target-feature=+mte"]
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ tags
 target
 .z3-trace
 foo
-.cargo
+.cargo/*
+!.cargo/config.toml
 publish
 vendor
 examples/build

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -712,12 +712,16 @@ impl Instance {
     }
 
     fn validate_inbounds(&self, max: usize, ptr: u64, len: u64) -> Result<usize, Trap> {
-        #[cfg(all(target_arch = "aarch64", target_os = "linux", target_feature = "mte"))]
+        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
         fn strip_mte_tag(ptr: u64) -> u64 {
-            ptr & 0xF0FF_FFFF_FFFF_FFFF
+            if std::arch::is_aarch64_feature_detected!("mte") {
+                ptr & 0xF0FF_FFFF_FFFF_FFFF
+            } else {
+                ptr
+            }
         }
 
-        #[cfg(not(all(target_arch = "aarch64", target_os = "linux", target_feature = "mte")))]
+        #[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
         fn strip_mte_tag(ptr: u64) -> u64 {
             ptr
         }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -712,16 +712,12 @@ impl Instance {
     }
 
     fn validate_inbounds(&self, max: usize, ptr: u64, len: u64) -> Result<usize, Trap> {
-        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+        #[cfg(all(target_arch = "aarch64", target_os = "linux", target_feature = "mte"))]
         fn strip_mte_tag(ptr: u64) -> u64 {
-            if std::arch::is_aarch64_feature_detected!("mte") {
-                ptr & 0xF0FF_FFFF_FFFF_FFFF
-            } else {
-                ptr
-            }
+            ptr & 0xF0FF_FFFF_FFFF_FFFF
         }
 
-        #[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
+        #[cfg(not(all(target_arch = "aarch64", target_os = "linux", target_feature = "mte")))]
         fn strip_mte_tag(ptr: u64) -> u64 {
             ptr
         }


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
Given our current workflow, which is to compile wasmtime only for the `aarch64-unknown-linux-gnu` triple with e.g. `cargo build --release --target aarch64-unknown-linux-gnu`, requiring the "mte" target feature in a conditional compile-time if statement doesn't work, since I am unaware of a way to specify target features using cargo when cross compiling to aarch64. For now, the best solution seems to be to insert a runtime if/check for mte.