### PR TITLE
Only enable MTE if MTE target feature is configured

### DIFF
--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -313,13 +313,9 @@ impl Mmap {
     }
 
     /// Make memory accessible while enabling mte
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    #[cfg(all(target_arch = "aarch64", target_os = "linux", target_feature = "mte"))]
     fn make_accessible_with_mte(&mut self, start: usize, len: usize) -> Result<bool> {
         use std::io;
-
-        if !std::arch::is_aarch64_feature_detected!("mte") {
-            return Ok(false);
-        }
 
         const PR_SET_TAGGED_ADDR_CTRL: i32 = 55;
         const PR_TAGGED_ADDR_ENABLE: u64 = 1 << 0;
@@ -379,7 +375,7 @@ impl Mmap {
     }
 
     /// We don't support MTE on non arm64 linux
-    #[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
+    #[cfg(not(all(target_arch = "aarch64", target_os = "linux", target_feature = "mte")))]
     fn make_accessible_with_mte(&mut self, _start: usize, _len: usize) -> Result<bool> {
         Ok(false)
     }


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
As we have agreed on in #11, it probably makes sense to use conditional compilation for MTE-specific code.
One use-case we had a while back was wanting to cross-compile to `aarch64-unknown-linux-gnu` but without MTE enabled, and then run that on an MTE enabled QEMU VM. This was not possible without commenting out code. With this change, one would simply have to disable the target feature for MTE.